### PR TITLE
Derive the Hash trait

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,1 +1,0 @@
-- implement Hash trait

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ impl Generator {
     pub fn new_id_with_time(&self, t: SystemTime) -> Result<ID, IDGenerationError> {
         match t.duration_since(UNIX_EPOCH) {
             Ok(n) => Ok(self.generate(n.as_secs())),
-            Err(e) => Err(IDGenerationError(e.description().to_string())),
+            Err(e) => Err(IDGenerationError(e.to_string())),
         }
     }
 


### PR DESCRIPTION
Changes:

1. Derive the `Hash` trait for `ID`
1. Remove a deprecated call to `.description()`
1. Added 3 tests showing various ways to use the `ID` with a `HashMap`